### PR TITLE
Changed logging method and fixed bug when left clicking a door

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.lptp1'
-version = '1.1'
+version = '1.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/me/lptp1/doubledoors/DoubleDoors.java
+++ b/src/main/java/me/lptp1/doubledoors/DoubleDoors.java
@@ -6,9 +6,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.logging.Logger;
 
 public final class DoubleDoors extends JavaPlugin {
-    
+
     private Logger log;
-    
+
     @Override
     public void onEnable() {
         log = getLogger();
@@ -17,7 +17,7 @@ public final class DoubleDoors extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new InteractWithDoorEvent(), this);
         log.info("DoubleDoors has been enabled!");
     }
-    
+
     @Override
     public void onDisable() {
         // Plugin shutdown logic

--- a/src/main/java/me/lptp1/doubledoors/DoubleDoors.java
+++ b/src/main/java/me/lptp1/doubledoors/DoubleDoors.java
@@ -3,19 +3,24 @@ package me.lptp1.doubledoors;
 import me.lptp1.doubledoors.events.InteractWithDoorEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public final class DoubleDoors extends JavaPlugin {
+import java.util.logging.Logger;
 
+public final class DoubleDoors extends JavaPlugin {
+    
+    private Logger log;
+    
     @Override
     public void onEnable() {
+        log = getLogger();
         // Plugin startup logic
-        System.out.println("DoubleDoors is starting up...");
+        log.info("DoubleDoors is starting up...");
         getServer().getPluginManager().registerEvents(new InteractWithDoorEvent(), this);
-        System.out.println("DoubleDoors has been enabled!");
+        log.info("DoubleDoors has been enabled!");
     }
-
+    
     @Override
     public void onDisable() {
         // Plugin shutdown logic
-        System.out.println("DoubleDoors has been disabled!");
+        log.info("DoubleDoors has been disabled!");
     }
 }

--- a/src/main/java/me/lptp1/doubledoors/events/InteractWithDoorEvent.java
+++ b/src/main/java/me/lptp1/doubledoors/events/InteractWithDoorEvent.java
@@ -12,32 +12,32 @@ import org.bukkit.block.BlockFace;
 public class InteractWithDoorEvent implements Listener {
     @EventHandler
     public void onInteractWithDoor(PlayerInteractEvent event) { // This method is called when a player interacts with a block
-        
+
         // Check if the block the player interacted with is a door, but not a trapdoor
         // Also check if the event was actually a right click
         if (!DoorUtils.isDoorBlock(event.getClickedBlock()) || !event.getAction().isRightClick()) {
             return;
         }
-        
+
         Block doorBlock = event.getClickedBlock();
         BlockState doorState = doorBlock.getState();
         Door door = (Door) doorState.getBlockData();
-        
+
         boolean newDoorState = !door.isOpen();
-        
+
         if (door.getFacing() == BlockFace.NORTH || door.getFacing() == BlockFace.SOUTH) {
             Block eastBlock = doorBlock.getRelative(BlockFace.EAST, 1);
             Block westBlock = doorBlock.getRelative(BlockFace.WEST, 1);
             updateNextDoors(door, eastBlock, westBlock, newDoorState);
         }
-        
+
         if (door.getFacing() == BlockFace.EAST || door.getFacing() == BlockFace.WEST) {
             Block northBlock = doorBlock.getRelative(BlockFace.NORTH, 1);
             Block southBlock = doorBlock.getRelative(BlockFace.SOUTH, 1);
             updateNextDoors(door, northBlock, southBlock, newDoorState);
         }
     }
-    
+
     private void updateNextDoors(Door originalDoor, Block block1, Block block2, boolean open) {
         if (DoorUtils.isDoorBlock(block1)) {
             BlockState doorState1 = block1.getState();

--- a/src/main/java/me/lptp1/doubledoors/events/InteractWithDoorEvent.java
+++ b/src/main/java/me/lptp1/doubledoors/events/InteractWithDoorEvent.java
@@ -12,31 +12,32 @@ import org.bukkit.block.BlockFace;
 public class InteractWithDoorEvent implements Listener {
     @EventHandler
     public void onInteractWithDoor(PlayerInteractEvent event) { // This method is called when a player interacts with a block
-
+        
         // Check if the block the player interacted with is a door, but not a trapdoor
-        if (!DoorUtils.isDoorBlock(event.getClickedBlock())) {
+        // Also check if the event was actually a right click
+        if (!DoorUtils.isDoorBlock(event.getClickedBlock()) || !event.getAction().isRightClick()) {
             return;
         }
-
+        
         Block doorBlock = event.getClickedBlock();
         BlockState doorState = doorBlock.getState();
         Door door = (Door) doorState.getBlockData();
-
+        
         boolean newDoorState = !door.isOpen();
-
+        
         if (door.getFacing() == BlockFace.NORTH || door.getFacing() == BlockFace.SOUTH) {
             Block eastBlock = doorBlock.getRelative(BlockFace.EAST, 1);
             Block westBlock = doorBlock.getRelative(BlockFace.WEST, 1);
             updateNextDoors(door, eastBlock, westBlock, newDoorState);
         }
-
+        
         if (door.getFacing() == BlockFace.EAST || door.getFacing() == BlockFace.WEST) {
             Block northBlock = doorBlock.getRelative(BlockFace.NORTH, 1);
             Block southBlock = doorBlock.getRelative(BlockFace.SOUTH, 1);
             updateNextDoors(door, northBlock, southBlock, newDoorState);
         }
     }
-
+    
     private void updateNextDoors(Door originalDoor, Block block1, Block block2, boolean open) {
         if (DoorUtils.isDoorBlock(block1)) {
             BlockState doorState1 = block1.getState();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: DoubleDoors
 version: '${version}'
+author: LPTP1
 main: me.lptp1.doubledoors.DoubleDoors
 description: A plugin that allows you to open two doors at once.
 api-version: 1.20


### PR DESCRIPTION
Changed logging method to remove warning about use of System.out on startup. Added a check to stop a left click from a player from opening an adjacent door.